### PR TITLE
UTF-8 related issue

### DIFF
--- a/iceshelf
+++ b/iceshelf
@@ -256,8 +256,8 @@ def gatherData():
         tmp2.append(k)
 
     manifest = {"modified" : tmp1, "deleted" : tmp2, "moved" : movedFiles, "previousbackup" : lastBackup}
-    with open(file_manifest, "wb") as fp:
-      json.dump(manifest, fp)
+    with open(file_manifest, "w") as fp:
+      fp.write(json.dumps(manifest, ensure_ascii=False).encode("utf-8"))
 
   # Security for the archive
   if config["encrypt"] and havearchive:
@@ -706,7 +706,7 @@ saveData = {
   "lastbackup" : config["prefix"] + config["unique"]
 }
 with open(config["file-checksum"] + "_tmp", "wb") as fp:
-  json.dump(saveData, fp)
+  fp.write(json.dumps(saveData, ensure_ascii=False).encode("utf-8"))
 
 # Copy the new file into place and then delete the temp file
 try:

--- a/iceshelf
+++ b/iceshelf
@@ -501,10 +501,10 @@ if cmdline.show:
   sys.exit(0)
 
 if cmdline.find:
-  logging.info("Searching for \"%s\"", cmdline.find)
+  logging.info("Searching for \"%s\"", cmdline.find.decode('utf-8'))
   found = 0
   for k,v in oldFiles.iteritems():
-    if k.lower().find(cmdline.find.lower()) is not -1:
+    if k.lower().find(cmdline.find.decode('utf-8').lower()) is not -1:
       logging.info("  \"%s\", exists in:", k)
       found += 1
       v["memberof"].sort()

--- a/iceshelf-restore
+++ b/iceshelf-restore
@@ -170,7 +170,7 @@ if config is None:
   sys.exit(1)
 
 if not os.path.isfile(cmdline.backup):
-  logging.error('"%s" is not a file' % cmdline.backup)
+  logging.error('"%s" is not a file' % cmdline.backup.decode('UTF-8'))
   sys.exit(1)
 
 basepath, files = getBackupFiles(cmdline.backup)
@@ -178,7 +178,7 @@ basepath, files = getBackupFiles(cmdline.backup)
 fileManifest = None
 fileArchive = None
 
-parity = False
+fileParity = None
 filelist = None
 oldfilelist = False
 corruptFiles = []
@@ -273,6 +273,9 @@ if cmdline.restore:
   if archive is None:
     logging.error('Unable to process "%s"' % fileArchive)
     sys.exit(1)
+else:
+    logging.info('No restore directory given. Exit.')
+    sys.exit(0)
 
 if fileManifest is None:
   logging.info('This is as much as can be done. You can now manually extract the files')
@@ -313,11 +316,11 @@ if cmdline.restore:
   with tarfile.open(archive, "r:*") as tar:
     item = tar.next()
     while item != None:
-      if '/' + item.name not in manifest['modified']:
-        logging.error('Archive contains "%s", not listed in the manifest' % item.name)
+      if '/' + item.name.decode('UTF-8') not in manifest['modified']:
+        logging.error('Archive contains "%s", not listed in the manifest' % item.name.decode('UTF-8'))
         fileerror += 1
       else:
-        manifest['modified']['/' + item.name]['found'] = True
+        manifest['modified']['/' + item.name.decode('UTF-8')]['found'] = True
         filecount -= 1
       item = tar.next()
 
@@ -362,7 +365,7 @@ if not cmdline.restore:
 with tarfile.open(archive, "r:*") as tar:
   item = tar.next()
   while item != None:
-    filename = os.path.normpath(cmdline.restore + "/" + item.name)
+    filename = os.path.normpath(cmdline.restore + "/" + item.name.decode('UTF-8'))
     logging.info('Extracting "%s" to "%s"' % (os.path.basename(filename), os.path.dirname(filename)))
     tar.extract(item, cmdline.restore)
     item = tar.next()


### PR DESCRIPTION
* decode filename decoded when use.  
* save manifest/json without escaped to ASCII. when open the files in editor, we see human readable UTF-8 characters, not escaped '\u1234'.
  * but not sure will have problem load previously saved manifest?
* Tested on python2.7 / ubuntu 17.04 / LC_CTYPE="en_US.UTF-8"
* BTW,  `parity` -> `fileParity` in `iceshelf-restore`. same as #11 