### PR TITLE
Upgrade scripts to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In order to be able to run this, you need a few other parts installed.
 
 - OpenPGP / GNU Privacy Guard (typically referred to as `gpg`)
 - python-gnupg - Encryption & Signature (NOT `gnupg`, it's `python-gnupg`)
-  Ubuntu comes with a version, but unfortunately it's too old. You should install this using the `pip` tool to make sure you get a current version.
+  Ubuntu comes with a version, but unfortunately it's too old. You should install this using the `pip3` tool to make sure you get a current version.
 - par2 - Parity tool
 - aws - In order to upload archive to glacier
 
@@ -87,11 +87,11 @@ This is the simple version which points out what commands to run. Please conside
 
 1. GPG
   Easy enough, ubuntu comes with it pre-installed
-2. GnuPG (requires PIP)
+2. GnuPG (requires pip3)
   ```
-  sudo apt-get install python-dev
-  sudo apt-get install python-pip
-  sudo pip install python-gnupg
+  sudo apt-get install python3-dev
+  sudo apt-get install python3-pip
+  sudo -H pip3 install python-gnupg
   ```
 
 3. PAR2 for parity
@@ -440,7 +440,7 @@ This is caused by your system clock being off by more than 5 minutes. It's highl
 ## When I run the tool, it says "Current GnuPG python module does not support file encryption, please check FAQ section in documentation"
 
 Unfortunately, there is both a gnupg and a python-gnupg implementation. This tool relies on the latter. If you get this error, then you've installed the `gnupg` version instead of `python-gnupg`.
-To fix this, please uninstall the wrong one using either the package manager or `sudo pip uninstall gnupg` followed by the correct one `sudo pip install python-gnupg`
+To fix this, please uninstall the wrong one using either the package manager or `sudo pip3 uninstall gnupg` followed by the correct one `sudo -H pip3 install python-gnupg`
 
 ## I get "Filename '&lt;some file&gt;' is corrupt, please rename it. Will be skipped for now" warnings
 

--- a/extras/iceshelf.service
+++ b/extras/iceshelf.service
@@ -13,7 +13,7 @@ Environment="ICESHELF=/home/iceshelf/iceshelf/iceshelf"
 Environment="CONFIG=/home/iceshelf/backup.conf"
 
 Type=simple
-ExecStart=/usr/bin/python ${ICESHELF} ${CONFIG}
+ExecStart=/usr/bin/python3 ${ICESHELF} ${CONFIG}
 
 # Restart if not finished
 RestartForceExitStatus=10

--- a/iceshelf
+++ b/iceshelf
@@ -521,10 +521,11 @@ if cmdline.show:
   sys.exit(0)
 
 if cmdline.find:
-  logging.info("Searching for \"%s\"", cmdline.find.decode('utf-8'))
+  logging.info("Searching for \"%s\"", cmdline.find)
   found = 0
-  for k,v in oldFiles.items():
-    if k.lower().find(cmdline.find.decode('utf-8').lower()) != -1:
+  query = cmdline.find.lower()
+  for k, v in oldFiles.items():
+    if query in k.lower():
       logging.info("  \"%s\", exists in:", k)
       found += 1
       v["memberof"].sort()

--- a/iceshelf-restore
+++ b/iceshelf-restore
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This tool will take a iceshelf backup and restore it to a
 # designated folder, following any directives stored in the
@@ -170,7 +170,7 @@ if config is None:
   sys.exit(1)
 
 if not os.path.isfile(cmdline.backup):
-  logging.error('"%s" is not a file' % cmdline.backup.decode('UTF-8'))
+  logging.error('"%s" is not a file' % cmdline.backup)
   sys.exit(1)
 
 basepath, files = getBackupFiles(cmdline.backup)
@@ -316,11 +316,11 @@ if cmdline.restore:
   with tarfile.open(archive, "r:*") as tar:
     item = tar.next()
     while item != None:
-      if '/' + item.name.decode('UTF-8') not in manifest['modified']:
-        logging.error('Archive contains "%s", not listed in the manifest' % item.name.decode('UTF-8'))
+      if '/' + item.name not in manifest['modified']:
+        logging.error('Archive contains "%s", not listed in the manifest' % item.name)
         fileerror += 1
       else:
-        manifest['modified']['/' + item.name.decode('UTF-8')]['found'] = True
+        manifest['modified']['/' + item.name]['found'] = True
         filecount -= 1
       item = tar.next()
 
@@ -365,7 +365,7 @@ if not cmdline.restore:
 with tarfile.open(archive, "r:*") as tar:
   item = tar.next()
   while item != None:
-    filename = os.path.normpath(cmdline.restore + "/" + item.name.decode('UTF-8'))
+    filename = os.path.normpath(cmdline.restore + "/" + item.name)
     logging.info('Extracting "%s" to "%s"' % (os.path.basename(filename), os.path.dirname(filename)))
     tar.extract(item, cmdline.restore)
     item = tar.next()


### PR DESCRIPTION
## Summary
- switch `iceshelf-restore` to Python 3 and update string handling
- remove `.decode()` usage in `iceshelf`
- document Python 3 install steps in the README
- update `iceshelf.service` to call python3
- run `pip3 install -r requirements.txt`

## Testing
- `python3 -m py_compile iceshelf iceshelf-restore modules/*.py`
- `pip3 install -r requirements.txt`
- `timeout 30 ./extras/testsuite/test.sh insecure` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68407110c838832085ce69b2d3b17839