### PR TITLE
Document database timestamp and add schema

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -5,6 +5,7 @@ Structure of the JSON database:
   "backups" : {...},
   "vault"   : "<name of the vault used>",
   "version" : [major, minor, revision],
+  "timestamp" : <seconds since epoch>,
   "moved" : {...} (optional),
   "lastbackup" : "<name of the previous successful backup>"
 }
@@ -61,3 +62,11 @@ All files which were deleted since last run
   "checksum" : "<hash>",          // Currently known version (blank if currently deleted)
   "memberof" : ["<backup>", ...]  // Which backups this file exists in
 }
+
+## Version history
+
+| Version | Changes |
+|---------|---------|
+| 1.0.0   | Added `version` and `timestamp` fields along with `dataset`, `backups` and `vault`. |
+| 1.0.1   | Internal move detection, manifest gained `moved` entries. Database format unchanged. |
+| 1.1.0   | Database now records `moved` entries and `lastbackup` of the previous run. Version key changed to an integer array. |

--- a/database.schema.json
+++ b/database.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "IceShelf Database",
+  "type": "object",
+  "required": ["dataset", "backups", "vault", "version", "timestamp"],
+  "properties": {
+    "dataset": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["checksum", "memberof", "deleted"],
+        "properties": {
+          "checksum": {"type": "string"},
+          "memberof": {"type": "array", "items": {"type": "string"}},
+          "deleted": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "backups": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {"type": "string"}
+      }
+    },
+    "vault": {"type": "string"},
+    "version": {
+      "type": "array",
+      "items": {"type": "integer"},
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "moved": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["reference", "original"],
+        "properties": {
+          "reference": {"type": "string"},
+          "original": {"type": "string"}
+        }
+      }
+    },
+    "lastbackup": {"type": "string"},
+    "timestamp": {"type": "number"}
+  }
+}


### PR DESCRIPTION
## Summary
- document the `timestamp` field in `DATABASE.md`
- describe historical changes in the JSON DB
- provide JSON Schema for the database format

## Testing
- `python3 -m py_compile iceshelf iceshelf-restore modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684fa1a7ff508320b786522045964bfe