### PR TITLE
Add provider framework and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If used with immutable storage, then it also provides protection against ransomw
 - Signs all files it uploads (tamper detection)
 - Can upload separate PAR2 file for parity correction (allows for a certain amount of bitrot)
 - Supports segmentation of upload (but not of files, yet)
-- Primarily designed for AWS Glacier but can be used with other services
+- Pluggable provider system supporting S3, SFTP, SCP and local copy
 - Tracks backups locally to help locate the file needed to restore
 - Keeps the exact directory structure of the backed up files
 - Provides paper-based GPG key backup/restore solution

--- a/iceshelf
+++ b/iceshelf
@@ -194,6 +194,7 @@ import modules.fileutils as fileutils
 import modules.helper as helper
 import modules.glacier as glacier
 import modules.aws as aws
+import modules.providers as providers
 
 lastBackup = None
 oldMoves = {}
@@ -408,6 +409,12 @@ tm = datetime.utcnow()
 config["unique"] = "%d%02d%02d-%02d%02d%02d-%05x" % (tm.year, tm.month, tm.day, tm.hour, tm.minute, tm.second, tm.microsecond)
 config["archivedir"] = os.path.join(config["prepdir"], config["unique"])
 
+# Instantiate backup provider
+provider = providers.get_provider(config.get("provider"))
+if provider is None:
+  logging.error("Invalid provider configuration")
+  sys.exit(1)
+
 """
 Load the old data, containing checksums and backup sets
 """
@@ -613,20 +620,9 @@ logging.info(msg)
 
 # We want to avoid wasting requests, so only try to
 # create vaults if we need to.
-backup = False
-if config["glacier-vault"] is not None:
-  if config["glacier-vault"] != oldVault:
-    logging.info("Glacier vault most likely not in cloud, let's create it")
-    if aws.createVault(config):
-      backup = aws.uploadFiles(config, files, totalbytes)
-  else:
-    backup = aws.uploadFiles(config, files, totalbytes)
-else:
-  logging.info("Not uploading to Glacier since config is missing")
-  backup = True
-
+backup = provider.upload_files([os.path.join(config["prepdir"], f) for f in files])
 if not backup:
-  logging.error("Amazon Glacier upload failed, aborting")
+  logging.error("Backup provider failed to store files")
   sys.exit(1)
 
 #

--- a/iceshelf.sample.conf
+++ b/iceshelf.sample.conf
@@ -158,6 +158,12 @@ skip empty: no
 vault: A-really-good-name-for-where-you-keep-backups
 threads: 4
 
+# Provider settings control where files are stored. Type can be cp, sftp, scp or s3.
+# Each provider has its own required arguments documented in providers/*.md
+[provider]
+type: cp
+dest: backup/done/
+
 # Run custom command before and/or after backup
 #
 # "pre command" is run before anything is done

--- a/modules/configuration.py
+++ b/modules/configuration.py
@@ -83,6 +83,10 @@ def parse(filename, onlysecurity=False):
       "create filelist": "yes",
       "check update": "no"
     },
+    "provider": {
+      "type": "cp",
+      "dest": "backup/done/"
+    },
     "glacier": {
       "vault": "",
       "threads": "4"
@@ -302,6 +306,18 @@ def parse(filename, onlysecurity=False):
       logging.error("Source \"%s\" points to a non-existing entry \"%s\"", x, config.get("sources", x))
       return None
     setting["sources"][x] = config.get("sources", x)
+
+  # Provider options
+  setting["provider"] = None
+  if config.has_section("provider"):
+    provider_cfg = {k: v for k, v in config.items("provider")}
+    if 'type' not in provider_cfg:
+      logging.error('Provider section must contain a type option')
+      return None
+    setting["provider"] = provider_cfg
+  else:
+    logging.error('Configuration missing provider section')
+    return None
 
   # Glacier options
   if config.has_section("glacier"):

--- a/modules/providers/__init__.py
+++ b/modules/providers/__init__.py
@@ -1,0 +1,44 @@
+import shutil
+import logging
+
+class BackupProvider:
+    """Base class for backup providers."""
+
+    def __init__(self, **options):
+        self.options = options
+
+    def verify(self):
+        """Return True if the provider configuration is valid."""
+        raise NotImplementedError
+
+    def upload_files(self, files):
+        """Upload a list of files."""
+        raise NotImplementedError
+
+
+def _which(program):
+    return shutil.which(program)
+
+from . import sftp, s3, scp, copy
+
+PROVIDERS = {
+    'sftp': sftp.SFTPProvider,
+    's3': s3.S3Provider,
+    'scp': scp.SCPProvider,
+    'cp': copy.CopyProvider,
+}
+
+def get_provider(cfg):
+    if not cfg or 'type' not in cfg:
+        raise ValueError('Provider configuration missing type')
+    t = cfg['type'].lower()
+    cls = PROVIDERS.get(t)
+    if not cls:
+        raise ValueError('Unknown provider: %s' % t)
+    opts = dict(cfg)
+    opts.pop('type', None)
+    provider = cls(**opts)
+    if not provider.verify():
+        logging.error('Provider verification failed for %s', t)
+        return None
+    return provider

--- a/modules/providers/copy.py
+++ b/modules/providers/copy.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+import logging
+from . import BackupProvider, _which
+
+class CopyProvider(BackupProvider):
+    """Simple provider that copies files locally using cp."""
+    def verify(self):
+        dest = self.options.get('dest')
+        if not dest:
+            logging.error('copy provider requires "dest"')
+            return False
+        if not os.path.isdir(dest):
+            logging.error('Destination %s does not exist', dest)
+            return False
+        if _which('cp') is None:
+            logging.error('cp command not found')
+            return False
+        self.dest = dest
+        return True
+
+    def upload_files(self, files):
+        for f in files:
+            try:
+                shutil.copy(f, os.path.join(self.dest, os.path.basename(f)))
+            except Exception:
+                logging.exception('Failed to copy %s', f)
+                return False
+        return True

--- a/modules/providers/s3.py
+++ b/modules/providers/s3.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import logging
+from . import BackupProvider, _which
+
+class S3Provider(BackupProvider):
+    def verify(self):
+        self.bucket = self.options.get('bucket')
+        self.prefix = self.options.get('prefix', '')
+        if not self.bucket:
+            logging.error('s3 provider requires "bucket"')
+            return False
+        if _which('aws') is None:
+            logging.error('aws command not found')
+            return False
+        return True
+
+    def upload_files(self, files):
+        for f in files:
+            key = os.path.join(self.prefix, os.path.basename(f))
+            cmd = ['aws', 's3', 'cp', f, f's3://{self.bucket}/{key}']
+            try:
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate()
+                if p.returncode != 0:
+                    logging.error('aws s3 cp failed: %s', err)
+                    return False
+            except Exception:
+                logging.exception('aws s3 cp failed for %s', f)
+                return False
+        return True

--- a/modules/providers/scp.py
+++ b/modules/providers/scp.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import logging
+from . import BackupProvider, _which
+
+class SCPProvider(BackupProvider):
+    def verify(self):
+        self.user = self.options.get('user')
+        self.host = self.options.get('host')
+        self.dest = self.options.get('dest', '.')
+        if not self.user or not self.host:
+            logging.error('scp provider requires "user" and "host"')
+            return False
+        if _which('scp') is None:
+            logging.error('scp command not found')
+            return False
+        return True
+
+    def upload_files(self, files):
+        for f in files:
+            dest = f'{self.user}@{self.host}:{self.dest}/{os.path.basename(f)}'
+            cmd = ['scp', f, dest]
+            try:
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate()
+                if p.returncode != 0:
+                    logging.error('scp failed: %s', err)
+                    return False
+            except Exception:
+                logging.exception('scp failed for %s', f)
+                return False
+        return True

--- a/modules/providers/sftp.py
+++ b/modules/providers/sftp.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+import logging
+from . import BackupProvider, _which
+
+class SFTPProvider(BackupProvider):
+    def verify(self):
+        self.user = self.options.get('user')
+        self.host = self.options.get('host')
+        self.dest = self.options.get('dest', '.')
+        if not self.user or not self.host:
+            logging.error('sftp provider requires "user" and "host"')
+            return False
+        if _which('sftp') is None:
+            logging.error('sftp command not found')
+            return False
+        return True
+
+    def upload_files(self, files):
+        for f in files:
+            cmd = ['sftp', f'{self.user}@{self.host}']
+            batch = f'put {f} {self.dest}/{os.path.basename(f)}\n'
+            try:
+                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                out, err = p.communicate(batch.encode())
+                if p.returncode != 0:
+                    logging.error('sftp failed: %s', err)
+                    return False
+            except Exception:
+                logging.exception('sftp failed for %s', f)
+                return False
+        return True

--- a/providers/cp.md
+++ b/providers/cp.md
@@ -1,0 +1,14 @@
+# Copy Provider
+
+Copies backup files to a local destination using the `cp` command. Useful when
+keeping archives on the same system or on a mounted network share.
+
+## Arguments
+- `dest` – path to the target directory where files will be placed.
+
+## Pros
+- Simple and uses basic tools available on any system.
+- No network transfer required.
+
+## Cons
+- Provides no remote storage or redundancy.

--- a/providers/s3.md
+++ b/providers/s3.md
@@ -1,0 +1,15 @@
+# Amazon S3 Provider
+
+Uses `aws s3 cp` to upload files to an S3 bucket.
+
+## Arguments
+- `bucket` – name of the target S3 bucket.
+- `prefix` – optional prefix inside the bucket.
+
+## Pros
+- Objects can be stored in immutable storage classes (e.g. Glacier or Glacier Deep Archive) which protects against ransomware.
+- Highly durable and available.
+
+## Cons
+- Requires the AWS CLI and credentials.
+- Transfer costs may apply.

--- a/providers/scp.md
+++ b/providers/scp.md
@@ -1,0 +1,15 @@
+# SCP Provider
+
+Transfers files using the `scp` command.
+
+## Arguments
+- `user` – user to connect as.
+- `host` – remote host.
+- `dest` – remote directory for the uploaded files.
+
+## Pros
+- Easy to use and available on most systems.
+
+## Cons
+- Requires SSH credentials.
+- Does not resume interrupted uploads.

--- a/providers/sftp.md
+++ b/providers/sftp.md
@@ -1,0 +1,15 @@
+# SFTP Provider
+
+Uploads backup files using the `sftp` command.
+
+## Arguments
+- `user` – user to connect as.
+- `host` – remote host.
+- `dest` – remote directory where files are uploaded.
+
+## Pros
+- Works over SSH and is widely supported.
+
+## Cons
+- Requires SSH access and credentials.
+- Transfer speed may be limited by network latency.


### PR DESCRIPTION
## Summary
- add provider classes for S3, SFTP, SCP and cp
- parse provider section in config
- update README with provider system
- document each provider
- integrate provider usage into main tool

## Testing
- `python -m py_compile modules/providers/*.py modules/*.py iceshelf iceshelf-restore`
- `./extras/testsuite/test.sh` *(fails: par2 and gnupg missing)*

------
https://chatgpt.com/codex/tasks/task_e_684fa5aa253c83209d4bdff1aca7ea9c