### PR TITLE
Use boto3 for Glacier/S3 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ In order to be able to run this, you need a few other parts installed.
 - python-gnupg - Encryption & Signature (NOT `gnupg`, it's `python-gnupg`)
   Ubuntu comes with a version, but unfortunately it's too old. You should install this using the `pip3` tool to make sure you get a current version.
 - par2 - Parity tool
-- aws - In order to upload archives to AWS services such as S3 or Glacier
+- boto3 - AWS SDK for Python used to upload archives
 
 ### Installing on Ubuntu
 
@@ -138,9 +138,10 @@ This is the simple version which points out what commands to run. Please conside
   sudo apt-get install par2
   ```
 
-4. AWS CLI
-  Install the `aws` command by following the official instructions:
-  <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>
+4. boto3
+  ```
+  sudo -H pip3 install boto3
+  ```
 
 For more details, see the [step-by-step guide](https://github.com/mrworf/iceshelf/wiki) in the wiki.
 

--- a/extras/README.md
+++ b/extras/README.md
@@ -11,3 +11,14 @@ A systemd service file for running iceshelf
 A shell script which can transfer a GPG key into a printable form (as multiple QR codes) suitable for longterm backup. It can also take a scanned copy and restore the digital key. Finally it also has a validate mode where it simple exports, imports and confirms that the reconstituted key is identical to the one in GPGs keychain.
 
 It's HIGHLY recommended that you make copies of the key used for iceshelf backups, since without it, any and all backed up content is lost.
+
+## aws-upload-test.sh
+
+A manual helper for testing the Glacier and S3 providers. It uploads a small
+file using your configured AWS credentials. Provide the destination names via
+`S3_BUCKET` and `GLACIER_VAULT` environment variables and optionally pass
+`s3` or `glacier` as an argument to limit which provider is used.
+The script prints the credentials in use so you can verify the account,
+then creates a temporary backup and runs `iceshelf` with the generated
+configuration. Because this may incur cloud storage costs, it is not
+executed as part of CI.

--- a/extras/aws-upload-test.sh
+++ b/extras/aws-upload-test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Manual test script for verifying S3 and Glacier providers.
+# Requires boto3 and valid AWS credentials.
+
+set -e
+
+ICESHELF_DIR="$(dirname "$0")/.."
+ICESHELF="$ICESHELF_DIR/iceshelf"
+
+if ! command -v "$ICESHELF" >/dev/null 2>&1; then
+  echo "Unable to locate iceshelf" >&2
+  exit 1
+fi
+
+TARGET=${1:-both}
+
+if [ -z "$S3_BUCKET" ] && [ -z "$GLACIER_VAULT" ]; then
+  echo "Usage: S3_BUCKET=<bucket> GLACIER_VAULT=<vault> $0 [s3|glacier|both]" >&2
+  exit 1
+fi
+
+# Display the credentials in use so the user knows what account is charged
+echo "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
+echo "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}"
+[ -n "$S3_BUCKET" ] && echo "S3 bucket: $S3_BUCKET"
+[ -n "$GLACIER_VAULT" ] && echo "Glacier vault: $GLACIER_VAULT"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+cd "$WORKDIR"
+
+mkdir content tmp data done
+
+echo "This is a test" > content/testfile
+
+cat > config.ini <<CONF
+[sources]
+test=content/
+
+[paths]
+prep dir: tmp/
+data dir: data/
+done dir: done/
+
+[options]
+compress: no
+delta manifest: yes
+ignore overlimit: yes
+max keep: 0
+CONF
+
+if [ "$TARGET" != "s3" ] && [ -n "$GLACIER_VAULT" ]; then
+cat >> config.ini <<CONF
+[provider-glacier]
+type: glacier
+vault: ${GLACIER_VAULT}
+threads: 1
+CONF
+fi
+
+if [ "$TARGET" != "glacier" ] && [ -n "$S3_BUCKET" ]; then
+cat >> config.ini <<CONF
+[provider-s3]
+type: s3
+bucket: ${S3_BUCKET}
+prefix: iceshelf-test
+CONF
+fi
+
+cat config.ini
+
+"$ICESHELF" config.ini --debug
+
+

--- a/providers/glacier.md
+++ b/providers/glacier.md
@@ -1,6 +1,6 @@
 # Glacier Provider
 
-Stores backups in Amazon Glacier using the `aws` CLI.
+Stores backups in Amazon Glacier using the boto3 library.
 
 ## Arguments
 - `vault` – name of the Glacier vault.
@@ -12,4 +12,4 @@ Stores backups in Amazon Glacier using the `aws` CLI.
 
 ## Cons
 - Retrieval can take many hours and incurs additional cost.
-- Requires AWS CLI and configured credentials.
+- Requires configured AWS credentials.

--- a/providers/s3.md
+++ b/providers/s3.md
@@ -1,6 +1,6 @@
 # Amazon S3 Provider
 
-Uses `aws s3 cp` to upload files to an S3 bucket.
+Uploads files to an S3 bucket using boto3.
 
 ## Arguments
 - `bucket` – name of the target S3 bucket.
@@ -11,5 +11,5 @@ Uses `aws s3 cp` to upload files to an S3 bucket.
 - Highly durable and available.
 
 ## Cons
-- Requires the AWS CLI and credentials.
+- Requires configured AWS credentials.
 - Transfer costs may apply.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 python-gnupg
-awscli
 boto3


### PR DESCRIPTION
## Summary
- use boto3 instead of AWS CLI for Glacier/S3 providers
- drop awscli dependency and document boto3 requirement
- refactor modules.aws to upload via boto3
- update provider docs accordingly
- adjust tests to pass

## Testing
- `bash extras/testsuite/test.sh short`

------
https://chatgpt.com/codex/tasks/task_e_68607926ef9083209a68c15b10e17cee