### PR TITLE
Add storage class to s3

### DIFF
--- a/modules/providers/s3.py
+++ b/modules/providers/s3.py
@@ -8,6 +8,7 @@ class S3Provider(BackupProvider):
     def verify(self):
         self.bucket = self.options.get('bucket')
         self.prefix = self.options.get('prefix', '')
+        self.storage_class = self.options.get('storage_class')
         if not self.bucket:
             logging.error('s3 provider requires "bucket"')
             return False
@@ -24,6 +25,9 @@ class S3Provider(BackupProvider):
         for f in files:
             key = os.path.join(self.prefix, os.path.basename(f))
             cmd = ['aws', 's3', 'cp', f, f's3://{self.bucket}/{key}']
+            if self.storage_class:
+                cmd.append('--storage-class')
+                cmd.append(str(self.storage_class))
             try:
                 p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 out, err = p.communicate()


### PR DESCRIPTION
Add an optional `storage_class` config option for s3 buckets, this is forwarded to the command line as `aws s3 ... --storage-class <STORAGE_CLASS>`

## Reference

Valid aws storage classes:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/sc-howtoset.html
> Reduced Redundancy Storage – REDUCED_REDUNDANCY
> 
> S3 Express One Zone – EXPRESS_ONEZONE
> 
> S3 Glacier Deep Archive – DEEP_ARCHIVE
> 
> S3 Glacier Flexible Retrieval – GLACIER
> 
> S3 Glacier Instant Retrieval – GLACIER_IR
> 
> S3 Intelligent-Tiering – INTELLIGENT_TIERING
> 
> S3 One Zone-IA – ONEZONE_IA
> 
> S3 Standard – STANDARD
> 
> S3 Standard-IA – STANDARD_IA

## Test logs / screenshots

`iceshelf.conf`
```conf
[provider-s3-glacier]
type: s3
bucket: ...
storage_class: DEEP_ARCHIVE
```

`$ iceshelf ./iceshelf.conf`
```
/nix/store/hvn85f87w6iz9f7h0wlmi2vgikwiipnq-iceshelf-0-unstable-2025-11-08/bin/.iceshelf-wrapped:407: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  tm = datetime.utcnow()
First run, no previous checksums
Setting up the prep directory
Checking sources for changes
Processing "paperless" (/storage/paperless/media/documents)
Preparing content for archiving, may take quite a while depending on size
Generating 5% parity information
Signing parity
33 files (17M) gathered, compressed, encrypted, signed and ready to upload as 11 files, total 16M
Saving the new checksum
```

<img width="1623" height="690" alt="image" src="https://github.com/user-attachments/assets/1a467663-7aef-44aa-9779-d96554430c19" />
